### PR TITLE
feat: encryption upgrade and footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,6 +86,8 @@
     }
     .theme-btn:hover { background: var(--bg-2nd-h); color: var(--text); }
 
+    .site-footer { border-top: 1px solid var(--border); background: var(--bg-card); transition: background .2s, border-color .2s; }
+
     .btn-primary {
       background: linear-gradient(135deg, #0891b2, #06b6d4);
       box-shadow: 0 0 24px rgba(6,182,212,.25);
@@ -162,8 +164,17 @@
       </div>
     </div>
 
-    <p class="mt-4 mb-4 text-muted text-xs mono">Der Schlüssel verlässt nie deinen Browser.</p>
   </main>
+
+  <footer class="site-footer w-full py-4 mt-auto">
+    <div class="max-w-screen-lg mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-muted text-xs mono">
+      <div class="flex items-center gap-2">
+        <img src="/logo.svg" alt="SecureDrop" class="w-4 h-4 opacity-50" />
+        <span>SecureDrop &copy; 2025</span>
+      </div>
+      <span>Der Schlüssel verlässt nie deinen Browser · Zero-knowledge</span>
+    </div>
+  </footer>
 
   <script type="module" src="/js/theme.js"></script>
   <script type="module" src="/js/create.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -132,6 +132,16 @@
         <span class="absolute bottom-3 right-3 text-muted text-xs mono" id="charCount">0</span>
       </div>
 
+      <div class="mt-3">
+        <input
+          id="password"
+          type="password"
+          placeholder="Passwort (optional) …"
+          class="input-field w-full rounded-xl text-sm p-3 placeholder:text-slate-500"
+        />
+        <p class="mt-1.5 text-muted text-xs mono">Ohne Passwort ist der Link allein zum Entschlüsseln ausreichend.</p>
+      </div>
+
       <button id="createBtn" class="btn-primary mt-4 w-full py-3 text-white font-semibold rounded-xl text-sm">
         Link generieren
       </button>

--- a/public/note.html
+++ b/public/note.html
@@ -53,6 +53,8 @@
     .border-theme { border-color: var(--border); }
     .message-box { background: var(--bg-input); border: 1px solid var(--border); box-shadow: inset 0 2px 8px rgba(0,0,0,.15); }
     .site-header { background: var(--header-bg); border-bottom: 1px solid var(--header-border); backdrop-filter: blur(12px); transition: background .2s, border-color .2s; }
+    .input-field { background: var(--bg-input); border: 1px solid var(--border); color: var(--text); transition: background .2s, border-color .2s; }
+    .input-field:focus { box-shadow: 0 0 0 2px rgba(6,182,212,.3); outline: none; }
     .theme-btn { background: var(--bg-2nd); color: var(--text-muted); transition: background .2s, color .2s; }
     .theme-btn:hover { background: var(--bg-2nd-h); color: var(--text); }
 
@@ -98,6 +100,19 @@
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="60" stroke-dashoffset="20"/>
         </svg>
         Überprüfe Nachricht …
+      </div>
+
+      <div id="passwordWrapper" class="hidden mb-5">
+        <div class="inline-flex items-center gap-1.5 bg-cyan-500/10 border border-cyan-500/20 text-cyan-400 text-xs mono px-3 py-1.5 rounded-full mb-3">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          Passwortgeschützt
+        </div>
+        <input
+          id="passwordInput"
+          type="password"
+          placeholder="Passwort eingeben …"
+          class="input-field w-full rounded-xl text-sm p-3 placeholder:text-slate-500"
+        />
       </div>
 
       <div id="revealWrapper" class="hidden text-center">

--- a/public/note.html
+++ b/public/note.html
@@ -55,6 +55,7 @@
     .site-header { background: var(--header-bg); border-bottom: 1px solid var(--header-border); backdrop-filter: blur(12px); transition: background .2s, border-color .2s; }
     .input-field { background: var(--bg-input); border: 1px solid var(--border); color: var(--text); transition: background .2s, border-color .2s; }
     .input-field:focus { box-shadow: 0 0 0 2px rgba(6,182,212,.3); outline: none; }
+    .site-footer { border-top: 1px solid var(--border); background: var(--bg-card); transition: background .2s, border-color .2s; }
     .theme-btn { background: var(--bg-2nd); color: var(--text-muted); transition: background .2s, color .2s; }
     .theme-btn:hover { background: var(--bg-2nd-h); color: var(--text); }
 
@@ -144,8 +145,17 @@
       </div>
     </div>
 
-    <p class="mt-4 mb-4 text-muted text-xs mono">Der Schlüssel verlässt nie deinen Browser.</p>
   </main>
+
+  <footer class="site-footer w-full py-4 mt-auto">
+    <div class="max-w-screen-lg mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-muted text-xs mono">
+      <div class="flex items-center gap-2">
+        <img src="/logo.svg" alt="SecureDrop" class="w-4 h-4 opacity-50" />
+        <span>SecureDrop &copy; 2025</span>
+      </div>
+      <span>Der Schlüssel verlässt nie deinen Browser · Zero-knowledge</span>
+    </div>
+  </footer>
 
   <script type="module" src="/js/theme.js"></script>
   <script type="module" src="/js/note.js"></script>

--- a/src/client/create.ts
+++ b/src/client/create.ts
@@ -28,11 +28,40 @@ async function postNote(ciphertext: string): Promise<string> {
   return id;
 }
 
+/** Derives an AES-KW wrapping key from a password using PBKDF2 (600k iterations). */
+async function deriveWrappingKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  const base = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 600000, hash: 'SHA-256' },
+    base,
+    { name: 'AES-KW', length: 256 },
+    false,
+    ['wrapKey', 'unwrapKey']
+  );
+}
+
+/** Wraps the raw AES key with a password-derived AES-KW key and returns wrapped key and salt. */
+async function wrapKeyWithPassword(rawKey: ArrayBuffer, password: string): Promise<{ wrappedKey: ArrayBuffer; salt: Uint8Array<ArrayBuffer> }> {
+  const salt = crypto.getRandomValues(new Uint8Array(16)) as Uint8Array<ArrayBuffer>;
+  const wrappingKey = await deriveWrappingKey(password, salt);
+  const keyToWrap = await crypto.subtle.importKey('raw', rawKey, { name: 'AES-GCM', length: 256 }, true, ['encrypt']);
+  const wrappedKey = await crypto.subtle.wrapKey('raw', keyToWrap, wrappingKey, 'AES-KW');
+  return { wrappedKey, salt };
+}
+
+/** Builds the URL fragment — 3 parts without password, 4 parts with password. */
+async function buildFragment(id: string, rawKey: ArrayBuffer, iv: Uint8Array<ArrayBuffer>, password: string): Promise<string> {
+  if (!password) return `${id}.${toBase64url(rawKey)}.${toBase64url(iv)}`;
+  const { wrappedKey, salt } = await wrapKeyWithPassword(rawKey, password);
+  return `${id}.${toBase64url(wrappedKey)}.${toBase64url(iv)}.${toBase64url(salt)}`;
+}
+
 /** Hides the form and displays the shareable link. */
-function showNoteLink(id: string, rawKey: ArrayBuffer, iv: Uint8Array<ArrayBuffer>, messageEl: HTMLTextAreaElement, btn: HTMLButtonElement): void {
-  const fragment = `${id}.${toBase64url(rawKey)}.${toBase64url(iv)}`;
+function showNoteLink(id: string, fragment: string, messageEl: HTMLTextAreaElement, btn: HTMLButtonElement): void {
   messageEl.classList.add('hidden');
   btn.classList.add('hidden');
+  (document.getElementById('password') as HTMLInputElement)?.closest('.mt-3')?.classList.add('hidden');
   (document.getElementById('link') as HTMLInputElement).value = `${location.origin}/note/${id}#${fragment}`;
   document.getElementById('result')!.classList.remove('hidden');
 }
@@ -40,7 +69,7 @@ function showNoteLink(id: string, rawKey: ArrayBuffer, iv: Uint8Array<ArrayBuffe
 /** Resets the create button and shows an error alert. */
 function handleCreateError(btn: HTMLButtonElement): void {
   btn.disabled = false;
-  btn.textContent = 'Link erstellen';
+  btn.textContent = 'Link generieren';
   alert('Fehler beim Speichern. Bitte erneut versuchen.');
 }
 
@@ -58,10 +87,11 @@ async function createNote(): Promise<void> {
   const message = messageEl.value.trim();
   if (!message) return;
   const btn = initCreateButton();
+  const password = (document.getElementById('password') as HTMLInputElement)?.value ?? '';
   try {
     const { encrypted, rawKey, iv } = await encryptMessage(message);
     const id = await postNote(toBase64url(encrypted));
-    showNoteLink(id, rawKey, iv, messageEl, btn);
+    showNoteLink(id, await buildFragment(id, rawKey, iv, password), messageEl, btn);
   } catch {
     handleCreateError(btn);
   }

--- a/src/client/note.ts
+++ b/src/client/note.ts
@@ -16,11 +16,11 @@ function showError(msg: string): void {
   el('errorBox').classList.remove('hidden');
 }
 
-/** Validates the URL fragment and returns its parts, or null if invalid. */
+/** Validates the URL fragment (3 or 4 parts) and returns its parts, or null if invalid. */
 function validateFragment(fragment: string): string[] | null {
   if (!fragment) { showError('Ungültiger Link — kein Schlüssel im Fragment.'); return null; }
   const parts = fragment.split('.');
-  if (parts.length !== 3) { showError('Ungültiges Link-Format.'); return null; }
+  if (parts.length !== 3 && parts.length !== 4) { showError('Ungültiges Link-Format.'); return null; }
   return parts;
 }
 
@@ -32,13 +32,42 @@ async function fetchCiphertext(id: string): Promise<string> {
   return ciphertext;
 }
 
-/** Decrypts the ciphertext and renders the plaintext message in the UI. */
-async function decryptAndDisplay(ciphertextB64: string, keyB64: string, ivB64: string): Promise<void> {
-  const key = await crypto.subtle.importKey(
-    'raw', fromBase64url(keyB64), { name: 'AES-GCM' }, false, ['decrypt']
+/** Derives an AES-KW key from a password and salt using PBKDF2 (600k iterations). */
+async function deriveWrappingKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  const base = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 600000, hash: 'SHA-256' },
+    base,
+    { name: 'AES-KW', length: 256 },
+    false,
+    ['unwrapKey']
   );
+}
+
+/** Unwraps an AES-GCM decryption key using a password-derived AES-KW wrapping key. */
+async function unwrapDecryptKey(wrappedKeyB64: string, password: string, saltB64: string): Promise<CryptoKey> {
+  const wrappingKey = await deriveWrappingKey(password, fromBase64url(saltB64));
+  return crypto.subtle.unwrapKey(
+    'raw', fromBase64url(wrappedKeyB64), wrappingKey, 'AES-KW',
+    { name: 'AES-GCM' }, false, ['decrypt']
+  );
+}
+
+/** Imports the AES-GCM decryption key — directly for 3-part fragments, via password for 4-part. */
+async function importDecryptKey(parts: string[]): Promise<CryptoKey> {
+  if (parts.length === 3) {
+    return crypto.subtle.importKey('raw', fromBase64url(parts[1]), { name: 'AES-GCM' }, false, ['decrypt']);
+  }
+  const password = (el('passwordInput') as HTMLInputElement).value;
+  return unwrapDecryptKey(parts[1], password, parts[3]);
+}
+
+/** Decrypts the note ciphertext using the fragment parts and renders the plaintext message. */
+async function decryptAndDisplay(parts: string[], ciphertextB64: string): Promise<void> {
+  const key = await importDecryptKey(parts);
   const decrypted = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: fromBase64url(ivB64) }, key, fromBase64url(ciphertextB64)
+    { name: 'AES-GCM', iv: fromBase64url(parts[2]) }, key, fromBase64url(ciphertextB64)
   );
   el('loadingState').classList.add('hidden');
   el('messageBox').textContent = new TextDecoder().decode(decrypted);
@@ -51,20 +80,21 @@ async function revealNote(): Promise<void> {
   el('revealWrapper').classList.add('hidden');
   el('loadingState').classList.remove('hidden');
   const parts = location.hash.slice(1).split('.');
-  if (parts.length !== 3) return showError('Ungültiges Link-Format.');
-  const [id, keyB64, ivB64] = parts;
+  if (parts.length !== 3 && parts.length !== 4) return showError('Ungültiges Link-Format.');
+  const [id] = parts;
   try {
     const ciphertextB64 = await fetchCiphertext(id);
-    await decryptAndDisplay(ciphertextB64, keyB64, ivB64);
+    await decryptAndDisplay(parts, ciphertextB64);
   } catch (err) {
     showError(err instanceof Error ? err.message : 'Ein Fehler ist aufgetreten.');
   }
 }
 
-/** Validates the fragment and checks whether the note exists before showing the reveal button. */
+/** Validates the fragment, checks whether the note exists, and shows the password input if needed. */
 async function init(): Promise<void> {
   const parts = validateFragment(location.hash.slice(1));
   if (!parts) return;
+  if (parts.length === 4) el('passwordWrapper').classList.remove('hidden');
   el('loadingState').classList.remove('hidden');
   try {
     const res = await fetch(`/api/notes/${parts[0]}`, { method: 'HEAD' });


### PR DESCRIPTION
## Summary
- Optional password-protected encryption via PBKDF2 + AES-KW (closes #1)
- Footer component on all pages (closes #2)

## Changes

### Issue #1 — Password-protected encryption
- Password is optional — without password the link works as before (3-part fragment)
- With password: PBKDF2 (600k iterations, SHA-256) derives an AES-KW wrapping key
- AES-GCM key is wrapped with AES-KW, salt stored in URL fragment (4-part fragment)
- Server never sees the password or raw key
- Optional password input on create page
- Password input on note page shown only when required

### Issue #2 — Footer
- Minimal, theme-aware footer on both pages
- Shows logo, project name and privacy note

## Still open
- Issue #3: Shorter links (next branch)

## Test plan
- [ ] Create and open link without password
- [ ] Create link with password, open with correct password
- [ ] Create link with password, open with wrong password — expect error
- [ ] Footer renders correctly in dark and light mode