### PR TITLE
fix: replace duplicate express.json() calls with per-route middleware

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,14 +14,12 @@ const MAX_CIPHERTEXT_BYTES = 64 * 1024;
 const MAX_FILE_BYTES = 15 * 1024 * 1024;
 
 const app = express();
-app.use(express.json({ limit: '70kb' }));
-app.use(express.json({ limit: '20mb' }));
 app.use(express.static(PUBLIC_DIR));
 
 app.get('/', (_req, res) => res.send(homePage()));
 app.get('/create', (_req, res) => res.send(createPage()));
 
-app.post('/api/notes', (req, res) => {
+app.post('/api/notes', express.json({ limit: '70kb' }), (req, res) => {
   const { ciphertext } = req.body as { ciphertext?: string };
 
   if (!ciphertext || typeof ciphertext !== 'string')


### PR DESCRIPTION
Closes #15

## Changes

- Removed two conflicting global `express.json()` calls (70 KB and 20 MB).
- Added `express.json({ limit: '70kb' })` as route-level middleware on `POST /api/notes` to enforce the intended note size limit.
- Kept `express.json({ limit: '20mb' })` on `POST /api/files` (was already there — removed redundant global).

## Why

Both global middleware calls were registered. Express applies them in order, so the 20 MB limit silently overrode the 70 KB limit. The stricter note-upload limit was effectively dead code.