### PR TITLE
fix: remove dead code and improve type safety

### DIFF
--- a/src/client/upload.ts
+++ b/src/client/upload.ts
@@ -4,11 +4,6 @@ const toBase64url = (buf: ArrayBuffer | Uint8Array): string =>
   btoa(String.fromCharCode(...new Uint8Array(buf instanceof ArrayBuffer ? buf : buf.buffer)))
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 
-function fromBase64url(s: string): Uint8Array {
-  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
-  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
-}
-
 function el<T extends HTMLElement>(id: string): T {
   return document.getElementById(id) as T;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,7 +26,8 @@ class NoteStore {
     return this.notes.has(id);
   }
 
-  private evictExpired(): void {
+  /** @internal exposed for testing */
+  evictExpired(): void {
     const cutoff = Date.now() - TTL_MS;
     for (const [id, note] of this.notes) {
       if (note.createdAt < cutoff) this.notes.delete(id);


### PR DESCRIPTION
Closes #16

## Changes

### `src/client/upload.ts`
- Removed unused `fromBase64url` function — only `toBase64url` is used in this file.

### `src/store.ts`
- Removed `private` from `evictExpired()` and added `@internal` JSDoc.
- Allows test code in `feature/add-tests` to call `store.evictExpired()` directly without `(store as any)` escape hatches.